### PR TITLE
Improve action API

### DIFF
--- a/playtest/action.py
+++ b/playtest/action.py
@@ -1,4 +1,5 @@
 import re
+import abc
 from typing import Optional, Type, Sequence, Dict, TypeVar, Generic, Set
 
 import numpy as np
@@ -18,7 +19,7 @@ class InvalidActionError(RuntimeError):
 S = TypeVar("S", bound=FullState)
 
 
-class ActionInstance(Generic[S]):
+class ActionInstance(abc.ABC, Generic[S]):
     """Represent an instance of the action.
 
     The instance of the action can be of acted on.
@@ -40,26 +41,32 @@ class ActionInstance(Generic[S]):
         raise NotImplementedError(f"Action {self.__class__} was not implemented")
 
     @classmethod
+    @abc.abstractmethod
     def from_str(cls, action_str: str) -> "ActionInstance":
         raise NotImplementedError(f"Action {cls} was not implemented")
 
     @classmethod
+    @abc.abstractmethod
     def get_action_space(cls) -> spaces.Space:
         raise NotImplementedError(f"Action {cls} was not implemented")
 
+    @abc.abstractmethod
     def to_numpy_data(self) -> np.ndarray:
         raise NotImplementedError(f"Action {self.__class__} was not implemented")
 
     @staticmethod
+    @abc.abstractstaticmethod
     def to_numpy_data_null() -> np.ndarray:
         """Provide a default numpy representation if this action is not taken
         """
         raise NotImplementedError()
 
     @classmethod
+    @abc.abstractmethod
     def from_numpy(cls, array: np.ndarray) -> "ActionInstance":
         raise NotImplementedError(f"Action {cls} was not implemented")
 
+    @abc.abstractmethod
     def resolve(
         self, s: S, player_id: int, a: Optional[Announcer] = None
     ) -> Optional["ActionRange"]:
@@ -75,7 +82,7 @@ class ActionInstance(Generic[S]):
 AI = TypeVar("AI", bound=ActionInstance)
 
 
-class ActionRange(Generic[AI, S]):
+class ActionRange(abc.ABC, Generic[AI, S]):
     """Represent a range of action
 
     The action range is responsible for representing a set of potential
@@ -91,6 +98,7 @@ class ActionRange(Generic[AI, S]):
 
     player_id: int
 
+    @abc.abstractmethod
     def __init__(self, state: S, player_id: int):
         self.player_id = player_id
         self.actionable = True
@@ -98,27 +106,34 @@ class ActionRange(Generic[AI, S]):
     def __str__(self):
         return repr(self)
 
+    @abc.abstractmethod
     def __repr__(self):
         raise NotImplementedError(f"{self.__class__} is not implemented")
 
+    @abc.abstractmethod
     def __eq__(self, x):
         raise NotImplementedError()
 
     @classmethod
+    @abc.abstractmethod
     def get_action_space_possible(cls) -> spaces.Space:
         raise NotImplementedError(f"{cls} is not implemented")
 
+    @abc.abstractmethod
     def to_numpy_data(self) -> np.ndarray:
         raise NotImplementedError(f"{self.__class__} is not implemented")
 
     @classmethod
+    @abc.abstractmethod
     def to_numpy_data_null(cls) -> np.ndarray:
         raise NotImplementedError(f"{cls} is not implemented.")
 
+    @abc.abstractmethod
     def is_actionable(self) -> bool:
         """Return if this action is actionable"""
         raise NotImplementedError()
 
+    @abc.abstractmethod
     def is_valid(self, x: AI) -> bool:
         raise NotImplementedError()
 

--- a/playtest/action.py
+++ b/playtest/action.py
@@ -60,7 +60,15 @@ class ActionInstance(Generic[S]):
     def from_numpy(cls, array: np.ndarray) -> "ActionInstance":
         raise NotImplementedError(f"Action {cls} was not implemented")
 
-    def resolve(self, s: S, player_id: int, a: Optional[Announcer] = None):
+    def resolve(
+        self, s: S, player_id: int, a: Optional[Announcer] = None
+    ) -> Optional["ActionRange"]:
+        """This resolves the action
+
+        :return:
+            Return None if this action is complete resolved.
+            Can also return additional action range.
+        """
         raise NotImplementedError()
 
 

--- a/playtest/action.py
+++ b/playtest/action.py
@@ -234,6 +234,8 @@ class ActionSingleValue(ActionInstance[S]):
 
     def __init__(self, value: int):
         self.value = value
+        assert self.maximum_value is not None, "{self.__class__} must set max_value"
+        assert self.minimum_value is not None, "{self.__class__} must set min_value"
 
     def __repr__(self):
         return f"{self.key}({self.value})"

--- a/playtest/action.py
+++ b/playtest/action.py
@@ -326,11 +326,10 @@ class ActionValueInSetRange(ActionRange[AIS, S]):
         return action.value in self.values_set
 
     def value_to_position(self, value) -> int:
-        """Converting a value to int"""
-        raise NotImplementedError(self.__class__.__name__)
+        return value
 
     def position_to_value(self, pos: int):
-        raise NotImplementedError(self.__class__.__name__)
+        return pos
 
     @classmethod
     def get_action_space_possible(cls):
@@ -364,7 +363,7 @@ class ActionFactory(Generic[S]):
         self,
         s: S,
         player_id: int,
-        accepted_range: Optional[Sequence[Type[ActionRange]]],
+        accepted_range: Optional[Sequence[Type[ActionRange]]] = None,
     ) -> Sequence[ActionRange]:
         acceptable_action = []
         if accepted_range is None:

--- a/playtest/action.py
+++ b/playtest/action.py
@@ -179,6 +179,10 @@ class ActionBoolean(ActionInstance[S]):
 
 
 class ActionBooleanRange(ActionRange[AI, S]):
+    def __init__(self, state: S, player_id: int):
+        # For boolean state, no need to do things
+        self.actionable = True
+
     def __repr__(self):
         return f"{self.instance_class.key}" if self.actionable else ""
 
@@ -333,6 +337,9 @@ class ActionValueInSetRange(ActionRange[AIS, S]):
             return ""
         valid_value_str = ",".join([str(v) for v in sorted(self.values_set)])
         return f"{self.instance_class.key}([{valid_value_str}])"
+
+    def __eq__(self, x):
+        return self.__class__ == x.__class__ and self.values_set == x.values_set
 
     def is_actionable(self):
         return bool(self.values_set)

--- a/playtest/components/card.py
+++ b/playtest/components/card.py
@@ -162,7 +162,7 @@ class Deck(Component, Generic[C]):
             count = len(self)
         for _ in range(count):
             assert self.cards, f"Oops - Deck {self.__class__} ran out of card."
-            other.cards.append(self.cards.pop())
+            other.add(self.cards.pop())
 
     def pop(self, count=1, all=False) -> List[C]:
         if all:
@@ -176,7 +176,7 @@ class Deck(Component, Generic[C]):
         """Move a specific card to other deck"""
         assert isinstance(other, self.__class__)
         self.cards.remove(card)
-        other.cards.append(card)
+        other.add(card)
 
     def add(self, card: C):
         self.cards.append(card)

--- a/playtest/components/card.py
+++ b/playtest/components/card.py
@@ -28,7 +28,8 @@ class BaseCard(Component):
     total_unique_cards: int = 512
 
     def __init__(self, value: str, uid=None, test_watermark=None):
-        assert isinstance(value, str)
+        self.value = value
+        assert isinstance(value, str), f"{value} is not a value card value"
         # Ensure that value is stored in a canonical format
         self.value = self.struct_to_value(self.value_to_struct(value))
         self.uid = uid
@@ -164,12 +165,12 @@ class Deck(Component, Generic[C]):
             assert self.cards, f"Oops - Deck {self.__class__} ran out of card."
             other.add(self.cards.pop())
 
-    def pop(self, count=1, all=False) -> List[C]:
+    def pop(self, index=-1, count=1, all=False) -> List[C]:
         if all:
             count = len(self)
         cards_popped = []
         for _ in range(count):
-            cards_popped.append(self.cards.pop())
+            cards_popped.append(self.cards.pop(index))
         return cards_popped
 
     def move_to(self, other: "Deck", card: C):

--- a/playtest/components/card.py
+++ b/playtest/components/card.py
@@ -73,10 +73,7 @@ class BaseCard(Component):
     def get_observation_space(self) -> spaces.Space:
         # Represent a deck of 52 cards
         return spaces.Box(
-            low=0,
-            high=self.total_unique_cards,
-            shape=(1,),
-            dtype=np.uint8,
+            low=0, high=self.total_unique_cards, shape=(1,), dtype=np.uint8,
         )
 
     def to_numpy_data(self) -> int:
@@ -152,8 +149,7 @@ class Deck(Component, Generic[C]):
                 cards is not None
             ), "Must pass in cards parameter if not specified all_cards"
             cards = [
-                self.generic_card(c) if not isinstance(
-                    c, self.generic_card) else c
+                self.generic_card(c) if not isinstance(c, self.generic_card) else c
                 for c in cards
             ]
 

--- a/playtest/components/core.py
+++ b/playtest/components/core.py
@@ -28,11 +28,13 @@ class Component(abc.ABC):
     def from_data(cls, data):
         return cls(data)
 
+    @abc.abstractmethod
     def to_numpy_data(self):
-        raise NotImplementedError(f"{self.__class__} have not implemented method")
+        raise NotImplementedError()
 
+    @abc.abstractmethod
     def get_observation_space(self) -> spaces.Space:
-        raise NotImplementedError(f"{self.__class__} have not implemented method")
+        raise NotImplementedError()
 
     @property
     def observation_space(self) -> spaces.Space:

--- a/playtest/test_action.py
+++ b/playtest/test_action.py
@@ -43,6 +43,9 @@ def test_wait_numpy():
 class MockNewAction(ActionBoolean[MockState]):
     key = "new_action"
 
+    def resolve(self, s, player_id, a=None):
+        pass
+
 
 class MockNewActionRange(ActionBooleanRange[MockNewAction, MockState]):
     instance_class = MockNewAction

--- a/pt_blackjack/action.py
+++ b/pt_blackjack/action.py
@@ -16,17 +16,31 @@ from playtest.action import (
 class ActionHit(ActionBoolean[State]):
     key = "hit"
 
+    def resolve(self, s, player_id, a=None):
+        # TODO: move action resolve in here
+        pass
+
 
 class ActionHitRange(ActionBooleanRange[ActionHit, State]):
     instance_class = ActionHit
+
+    def __init__(self, state: State, player_id: int):
+        super().__init__(state, player_id)
 
 
 class ActionSkip(ActionBoolean[State]):
     key = "skip"
 
+    def resolve(self, s, player_id, a=None):
+        # TODO: move action resolve in here
+        pass
+
 
 class ActionSkipRange(ActionBooleanRange[ActionSkip, State]):
     instance_class = ActionSkip
+
+    def __init__(self, state: State, player_id: int):
+        super().__init__(state, player_id)
 
 
 # Sentinel Action instance for comparison
@@ -39,6 +53,10 @@ class ActionBet(ActionSingleValue[State]):
 
     minimum_value = 0
     maximum_value = 0xFF
+
+    def resolve(self, s, player_id, a=None):
+        # TODO: move action resolve in here
+        pass
 
 
 class ActionBetRange(ActionSingleValueRange[ActionBet, State]):


### PR DESCRIPTION
This provide a new action API which allow chaining actions.

The `action.resolve` can now return further `ActionRange` which can now request for further action.

For example,
```
action = ActionCardDecide(card1)
# Now action_range is a decision that needs to be made by card 1
action_range = action.resolve()
```
